### PR TITLE
Add rsync-based deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site
 public
 .sass-cache
 .jekyll-metadata
+**/.jekyll-cache/*
 .env
 .env.build
 cypress/screenshots

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ source "https://rubygems.org"
 # Happy Jekylling!
 gem "jekyll", "~> 4.0.0"
 
+# Use rake as a build system
+gem 'rake'
+gem 'dotenv'
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
@@ -26,8 +30,8 @@ end
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
   gem "tzinfo", "~> 1.2"
   gem "tzinfo-data"
-  gem 'eventmachine', '1.2.7', :platforms => :ruby
+  gem 'eventmachine', '1.2.7', platforms: :ruby
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
+gem "wdm", "~> 0.1.0", install_if: Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.6)
+    dotenv (2.7.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -57,6 +58,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.4)
+    rake (13.0.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -82,11 +84,13 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  dotenv
   eventmachine (= 1.2.7)
   jekyll (~> 4.0.0)
   jekyll-multiple-languages-plugin
   jekyll-sitemap
   jekyll-tidy
+  rake
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,122 @@
+# coding: utf-8
+task default: :preview
+
+require 'dotenv/load'
+
+# based on https://github.com/avillafiorita/jekyll-rakefile/ (MIT License)
+
+# launch compass
+$compass = false
+# check and warn before deploying if there are remote changes (if git is used)
+$git_check = true
+# commit and push after deploying
+$git_autopush = false
+
+# TODO: maybe read from ENV vars?
+$deploy_dir = "keedrop@cronos.illunis.net:"
+$rsync_rsh = "ssh -p 36077 -l keedrop -i #{ENV['DEPLOY_KEY']}"
+
+#
+# --- NO NEED TO TOUCH ANYTHING BELOW THIS LINE ---
+#
+
+
+#
+# Tasks start here
+#
+
+desc 'Clean up generated site'
+task :clean do
+  cleanup
+end
+
+
+desc 'Preview on local machine (server with --auto)'
+task preview: :clean do
+  compass('compile') # so that we are sure sass has been compiled before we run the server
+  compass('watch &')
+  jekyll('serve --watch')
+end
+task serve: :preview
+
+
+desc 'Build for deployment (but do not deploy)'
+task :build, [:deployment_configuration] => :clean do |t, args|
+  args.with_defaults(deployment_configuration: 'deploy')
+
+  if rake_running then
+    puts "\n\nWarning! An instance of rake seems to be running (it might not be *this* Rakefile, however).\n"
+    puts "Building while running other tasks (e.g., preview), might create a website with broken links.\n\n"
+    puts "Are you sure you want to continue? [Y|n]"
+
+    ans = STDIN.gets.chomp
+    exit if ans != 'Y' 
+  end
+
+  compass('compile')
+  jekyll("build --config _config.yml")
+end
+
+
+desc 'Build and deploy to remote server'
+task :deploy, [:deployment_configuration] => :build do |t, args|
+  args.with_defaults(deployment_configuration: 'deploy')
+
+  if git_requires_attention("master") then
+    puts "\n\nWarning! It seems that the local repository is not in sync with the remote.\n"
+    puts "This could be ok if the local version is more recent than the remote repository.\n"
+    puts "Deploying before committing might cause a regression of the website (at this or the next deploy).\n\n"
+    puts "Are you sure you want to continue? [Y|n]"
+
+    ans = STDIN.gets.chomp
+    exit if ans != 'Y' 
+  end
+
+  sh "rsync -av -e '#{$rsync_rsh}' --delete _site/ #{$deploy_dir}"
+  time = Time.new
+  File.open("_last_deploy.txt", 'w') {|f| f.write(time) }
+  %x{git add -A && git commit -m "autopush by Rakefile at #{time}" && git push} if $git_autopush
+end
+
+
+#
+# General support functions
+#
+
+# remove generated site
+def cleanup
+  sh 'rm -rf _site'
+  compass('clean')
+end
+
+# launch jekyll
+def jekyll(directives = '')
+  sh 'jekyll ' + directives
+end
+
+# launch compass
+def compass(command = 'compile')
+  (sh 'compass ' + command) if $compass
+end
+
+# check if there is another rake task running (in addition to this one!)
+def rake_running
+  `ps | grep 'rake' | grep -v 'grep' | wc -l`.to_i > 1
+end
+
+def git_local_diffs
+  %x{git diff --name-only} != ""
+end
+
+def git_remote_diffs branch
+  %x{git fetch}
+  %x{git rev-parse #{branch}} != %x{git rev-parse origin/#{branch}}
+end
+
+def git_repo?
+  %x{git status} != ""
+end
+
+def git_requires_attention branch
+  $git_check and git_repo? and git_remote_diffs(branch)
+end


### PR DESCRIPTION
I created a special deploy SSH key that can't do anything but rsync up some files to a specific directory. 

Although I guess it should also build the go binary and deploy it along the static site.