### PR TITLE
fix: set height to 100% instead of 100vh

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,11 +1,12 @@
-body {
+html, body {
   margin: 0;
+  height: 100%;
 }
 
 .container {
   text-align: center;
   max-width: 100vw;
-  min-height: 100vh;
+  height: 100%;
   padding: 0;
   margin: 0;
 }


### PR DESCRIPTION
100vh makes problems on mobiles, since they do not take into account the browsers address bar and other chrome.

The result was you had to scroll the page to see the imprint footer.